### PR TITLE
Interface fixes

### DIFF
--- a/src/hooks/useMarketStats.tsx
+++ b/src/hooks/useMarketStats.tsx
@@ -18,7 +18,12 @@ import { getLiquidationPrice } from '@/src/utils/GMX/getLiquidationPrice'
 import { getNextToAmount } from '@/src/utils/GMX/getNextToAmount'
 import { getUSDGStats } from '@/src/utils/GMX/getUSDGStats'
 import { expandDecimals } from '@/src/utils/GMX/numbers'
-import { FuturesMarketKey, KWENTA_FIXED_FEE, ZERO_BIG_NUM } from '@/src/utils/KWENTA/constants'
+import {
+  FuturesMarketKey,
+  KWENTA_FIXED_FEE,
+  ZERO_BIG_NUM,
+  zeroBN,
+} from '@/src/utils/KWENTA/constants'
 import { formatOrderSizes, formatPosition } from '@/src/utils/KWENTA/format'
 import { extractMarketInfo, getFillPrice } from '@/src/utils/KWENTA/getMarketInternalData'
 import { getMarketInternalData } from '@/src/utils/KWENTA/getMarketInternalData'
@@ -172,6 +177,8 @@ async function getGMXStatsFetcher(
     BigNumber.from(0)
 
   const borrowFeeAmount = nextToUsd.mul(borrowFee).div(BASIS_POINTS_DIVISOR).div(100)
+  const fillPrice = toTokenPriceUsd.div(BigNumber.from(10).pow(USD_DECIMALS - 18))
+  const positionValue = wei(amount).mul(leverage).toBN()
 
   // ----------------------
   // Set values
@@ -179,9 +186,9 @@ async function getGMXStatsFetcher(
 
   return {
     protocol: 'GMX',
-    position: nextToUsd.div(BigNumber.from(10).pow(USD_DECIMALS - 18)),
+    position: positionValue,
     investmentTokenSymbol: 'USDC',
-    fillPrice: toTokenPriceUsd.div(BigNumber.from(10).pow(USD_DECIMALS - 18)),
+    fillPrice: fillPrice,
     orderSize: nextToAmount, // 18
     priceImpact: undefined,
     protocolFee: positionFeeUsd.div(BigNumber.from(10).pow(USD_DECIMALS - 18)),
@@ -286,8 +293,8 @@ async function getKwentaStatsFetcher(
     fillPrice: fillPrice,
     orderSize: wei(margin).mul(leverage).div(marketData.assetPrice).toBN(),
     priceImpact: positionStats.priceImpact.toBN(),
-    protocolFee: positionStats.fee.add(KWENTA_FIXED_FEE).toBN(),
-    swapFee: positionStats.fee.toBN(),
+    protocolFee: positionStats.fee.toBN(),
+    swapFee: zeroBN.toBN(),
     executionFee: KWENTA_FIXED_FEE.toBN(),
     liquidationPrice: positionStats.liqPrice.toBN(),
     oneHourFunding: oneHourFunding,

--- a/src/pagePartials/index/OutputDetails.tsx
+++ b/src/pagePartials/index/OutputDetails.tsx
@@ -37,13 +37,6 @@ type Props = {
   positionSide: Position
 }
 export function OutputDetails({ comparison, local, margin, positionSide, tokenSymbol }: Props) {
-  const getTradeFeeText = (protocol: string) => {
-    const text =
-      protocol === 'Kwenta'
-        ? 'Fees are displayed as maker / taker. Maker fees apply to orders that reduce the market skew. Taker fees apply to orders that increase the market skew.'
-        : 'The cost of swapping tokens to execute the trade.'
-    return text
-  }
   const get1hrFundingText = (protocol: string) => {
     const text =
       protocol === 'Kwenta'
@@ -107,15 +100,13 @@ export function OutputDetails({ comparison, local, margin, positionSide, tokenSy
             Price Impact
           </Tooltip>
         </span>
-        <strong>{formatAmount(local.priceImpact)}</strong>
+        <strong>{formatAmount(local.priceImpact)}%</strong>
       </List>
       <List as={motion.li} variants={itemVariants}>
         <span>
           <Tooltip text="Fees the protocol charges for opening a position.">Protocol Fee</Tooltip>
         </span>
-        <strong>
-          {local.protocol === 'Kwenta' ? '-' : formatAmount(local.protocolFee, 18, 2)}{' '}
-        </strong>
+        <strong>{formatAmount(local.protocolFee, 18, 2)}</strong>
       </List>
       <List
         as={motion.li}
@@ -123,9 +114,7 @@ export function OutputDetails({ comparison, local, margin, positionSide, tokenSy
         variants={itemVariants}
       >
         <span>
-          <Tooltip text={getTradeFeeText(local.protocol)}>
-            {local.protocol === 'Kwenta' ? 'Trade Fee' : 'Swap Fee'}{' '}
-          </Tooltip>
+          <Tooltip text={'The cost of swapping tokens to execute the trade.'}>Swap Fee</Tooltip>
         </span>
         <strong>{formatAmount(local.swapFee, 18, 2)}</strong>
       </List>

--- a/src/pagePartials/index/OutputDetails.tsx
+++ b/src/pagePartials/index/OutputDetails.tsx
@@ -102,7 +102,11 @@ export function OutputDetails({ comparison, local, margin, positionSide, tokenSy
         </span>
         <strong>{formatAmount(local.priceImpact)}%</strong>
       </List>
-      <List as={motion.li} variants={itemVariants}>
+      <List
+        as={motion.li}
+        status={setStyle(local.protocolFee, comparison?.protocolFee)}
+        variants={itemVariants}
+      >
         <span>
           <Tooltip text="Fees the protocol charges for opening a position.">Protocol Fee</Tooltip>
         </span>

--- a/src/providers/dashboardProvider.tsx
+++ b/src/providers/dashboardProvider.tsx
@@ -42,7 +42,7 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
       protocolAForm: {
         name: 'Kwenta',
         chain: Chains.optimism,
-        url: 'https://kwenta.io/market/?asset=sETH',
+        url: 'https://kwenta.eth.limo/market/?asset=sETH',
       },
       protocolAStats: null,
       protocolBForm: {

--- a/src/providers/dashboardProvider.tsx
+++ b/src/providers/dashboardProvider.tsx
@@ -42,7 +42,7 @@ export const DashboardProvider: FC<PropsWithChildren> = ({ children }) => {
       protocolAForm: {
         name: 'Kwenta',
         chain: Chains.optimism,
-        url: 'https://kwenta.eth.limo/market/?asset=sETH',
+        url: 'https://kwenta.eth.limo/market/?asset=sETH&accountType=cross_margin',
       },
       protocolAStats: null,
       protocolBForm: {


### PR DESCRIPTION
Fix some display issues in the aggregation terminal:
* Replace `kwenta.io` link with `kwenta.eth.limo`
* Rename Kwenta `Trade Fee` back to `Swap Fee`
* Move Kwenta `Trade Fee` display to `Protocol Fees`
* Fix `Position` value on GMX, which was inconsistent with the calculations for Kwenta
* Add unit display (`%`) to the Price Impact field
* Fix sign on the "1H Funding" values. GMX should always be negative, and Kwenta should be adjusted depending on position and funding signs